### PR TITLE
Client Side Authorization

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -10,4 +10,3 @@ insecure
 kenton:accounts-sandstorm
 mike:mocha
 iron:router
-http

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -10,3 +10,4 @@ insecure
 kenton:accounts-sandstorm
 mike:mocha
 iron:router
+http

--- a/.sandstorm/sandstorm-pkgdef.capnp
+++ b/.sandstorm/sandstorm-pkgdef.capnp
@@ -40,7 +40,6 @@ const pkgdef :Spk.PackageDefinition = (
     # starting a new instance, but you could use different commands for each
     # case.
   ),
-
   sourceMap = (
     # The following directories will be copied into your package.
     searchPath = [
@@ -49,11 +48,13 @@ const pkgdef :Spk.PackageDefinition = (
     ]
   ),
 
-  alwaysInclude = [ "." ]
+  alwaysInclude = [ "." ],
   # This says that we always want to include all files from the source map.
   # (An alternative is to automatically detect dependencies by watching what
   # the app opens while running in dev mode. To see what that looks like,
   # run `spk init` without the -A option.)
+
+  bridgeConfig = (viewInfo = (permissions = [(name = "owner")]))
 );
 
 const myCommand :Spk.Manifest.Command = (

--- a/client/routes.js
+++ b/client/routes.js
@@ -1,0 +1,20 @@
+Router.isOwner = function(user) {
+  if (user === null) {
+    return false;
+  } else {
+    var permissions = user.services.sandstorm.permissions;
+    return _(permissions).contains("owner");
+  }
+}
+
+Router.route('/', function() {
+  if (Router.isOwner(Meteor.user())) {
+    this.render('create');
+  } else {
+    this.render('submit');
+  }
+});
+
+Router.route('/create');
+Router.route('/responses');
+Router.route('/submit');

--- a/client/subscribe.js
+++ b/client/subscribe.js
@@ -1,0 +1,1 @@
+Meteor.subscribe("userData");

--- a/create/create.html
+++ b/create/create.html
@@ -1,6 +1,8 @@
 
 <template name="create">
 
+  <a href="/responses">Responses</a>
+
   <h2>Create</h2>
 
   Prompt 1:<input type="text"><br>

--- a/index.html
+++ b/index.html
@@ -5,9 +5,3 @@
 <body>
   <h1>SandForms</h1>
 </body>
-
-<template name="index">
-  <a href="/create">Create</a>
-  <a href="/submit">Submit</a>
-  <a href="/responses">Responses</a>
-</template>

--- a/responses/responses.html
+++ b/responses/responses.html
@@ -1,6 +1,8 @@
 
 <template name="responses">
 
+  <a href="/create">Create Form</a>
+
   <h2>Responses</h2>
 
   <table>

--- a/routes.js
+++ b/routes.js
@@ -1,4 +1,0 @@
-Router.route('/', { name: 'index' });
-Router.route('/create');
-Router.route('/responses');
-Router.route('/submit');

--- a/server/add-dev-user-when-not-in-sandstorm.js
+++ b/server/add-dev-user-when-not-in-sandstorm.js
@@ -1,0 +1,26 @@
+Meteor.startup(function () {
+
+  var shouldInsertFakeHeaders = function(req) {
+    var devMode = process.env.NODE_ENV == 'development';
+    var headerExists = _(req.headers).has("x-sandstorm-user-id");
+    return devMode && (!headerExists);
+  }
+
+  var addSandstormUserHeaders = function(req, res, next) {
+    if (shouldInsertFakeHeaders(req)) {
+      req.headers["x-sandstorm-user-id"] = "local-user-id";
+      req.headers["x-sandstorm-username"] = "Local Dev User";
+      req.headers["x-sandstorm-permissions"] = "owner";
+    }
+    return next();
+  };
+
+  // Add the headers before any other handlers so that the
+  // kenton:accounts-sandstorm package picks them up
+  WebApp.rawConnectHandlers.stack.splice(0, 0, {
+    route: '',
+    handle: addSandstormUserHeaders
+  });
+});
+
+

--- a/server/publish.js
+++ b/server/publish.js
@@ -1,0 +1,11 @@
+Meteor.publish('userData', function() {
+  if (this.userId) {
+    var user = Meteor.users.find({
+      _id: this.userId
+    }, { fields: { 'services.sandstorm.permissions': 1 }});
+
+    return user;
+  } else {
+    this.ready();
+  }
+});

--- a/tests/mocha/client/IsOwnerSpec.js
+++ b/tests/mocha/client/IsOwnerSpec.js
@@ -1,0 +1,34 @@
+
+MochaWeb.testOnly(function() {
+
+  describe("isOwner", function() {
+
+    it("should return false when the user does not have the owner permission", function() {
+      // Given
+      var user = {
+        services: { sandstorm: { permissions: []}}
+      };
+
+      // When/Then
+      chai.expect(Router.isOwner(user)).to.be.false;
+    });
+
+    it("should return true when the user has the owner permission", function() {
+      // Given
+      var user = {
+        services: { sandstorm: { permissions: [ "owner" ]}}
+      };
+
+      // When/Then
+      chai.expect(Router.isOwner(user)).to.be.true;
+    });
+
+    it("should return false when the user is null", function() {
+      // When
+      var isOwner = Router.isOwner(null);
+
+      // Then
+      chai.expect(isOwner).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
This PR adds an "owner" permission to the sandstorm package, which lets us tell whether the current user created the document.

Then, instead of routing all users to an index page, the owner is routed to the create form page while everyone else is routed to the submit page.

There is also some code in `add-dev-user-when-not-in-sandstorm.js` to fake the sandstorm user headers when the app is ran directly from meteor (with `meteor` or `meteor run`).

Note that this is just client side routing! Server side authorization checks are coming soon...
