### PR TITLE
Hide create and responses links for non owners

### DIFF
--- a/client/routes.js
+++ b/client/routes.js
@@ -1,18 +1,9 @@
-Router.isOwner = function(user) {
-  if (user === null) {
-    return false;
-  } else {
-    var permissions = user.services.sandstorm.permissions;
-    return _(permissions).contains("owner");
-  }
-}
-
 Router.configure({
   layoutTemplate: 'index'
 });
 
 Router.route('/', function() {
-  if (Router.isOwner(Meteor.user())) {
+  if (User.isOwner(Meteor.user())) {
     this.render('create');
   } else {
     this.render('submit');

--- a/client/routes.js
+++ b/client/routes.js
@@ -3,7 +3,7 @@ Router.configure({
 });
 
 Router.route('/', function() {
-  if (User.isOwner(Meteor.user())) {
+  if (User.ownerLoggedIn()) {
     this.render('create');
   } else {
     this.render('submit');

--- a/collections/prompts.js
+++ b/collections/prompts.js
@@ -2,14 +2,10 @@ Prompts = new Mongo.Collection("prompts");
 
 Prompts.allow({
   insert: function(userId) {
-    var user = Meteor.users.findOne({_id: userId});
-    var permissions = user.services.sandstorm.permissions;
-    return permissions.indexOf('owner') > -1;
+    return User.isOwnersUserId(userId);
   },
   update: function(userId) {
-    var user = Meteor.users.findOne({_id: userId});
-    var permissions = user.services.sandstorm.permissions;
-    return permissions.indexOf('owner') > -1;
+    return User.isOwnersUserId(userId);
   }
 });
 

--- a/collections/submissions.js
+++ b/collections/submissions.js
@@ -9,9 +9,7 @@ Submissions.allow({
 if (Meteor.isServer) {
   Meteor.publish("submissions", function() {
     if (this.userId === null) return [];
-    var user = Meteor.users.findOne({_id: this.userId});
-    var permissions = user.services.sandstorm.permissions;
-    var isOwner = permissions.indexOf('owner') > -1;
+    var isOwner = User.isOwnersUserId(this.userId);
 
     if (isOwner) {
       return Submissions.find({});

--- a/index.html
+++ b/index.html
@@ -3,11 +3,7 @@
 </head>
 
 <template name="index">
-  <header class="navigation-bar__wrapper">
-    <h1 class="nagivation-bar__heading">SandForms</h1>
-    <a class="nagivation-bar__links" href="/create">Create</a>
-    <a class="nagivation-bar__links" href="/responses">Responses</a>
-  </header>
+  {{> _navigation}}
   <div class="main-content">
     {{> yield}}
   </div>

--- a/lib/nullOrUndefined.js
+++ b/lib/nullOrUndefined.js
@@ -1,0 +1,3 @@
+nullOrUndefined = function(x) {
+  return x === null || x === undefined;
+}

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,0 +1,12 @@
+User = {
+  isOwner: function(user) {
+    if (user === null) {
+      return false;
+    } else {
+      var permissions = user.services.sandstorm.permissions;
+      return _(permissions).contains("owner");
+    }
+  }
+
+
+}

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,12 +1,15 @@
-User = {
-  isOwner: function(user) {
-    if (user === null) {
-      return false;
-    } else {
-      var permissions = user.services.sandstorm.permissions;
-      return _(permissions).contains("owner");
-    }
+User = {}
+
+User.isOwner = function(user) {
+  if (user === null) {
+    return false;
+  } else {
+    var permissions = user.services.sandstorm.permissions;
+    return _(permissions).contains("owner");
   }
+};
 
 
+User.ownerLoggedIn = function() {
+  return User.isOwner(Meteor.user());
 }

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,7 +1,7 @@
-User = {}
+User = {};
 
 User.isOwner = function(user) {
-  if (user === null) {
+  if (nullOrUndefined(user)) {
     return false;
   } else {
     var permissions = user.services.sandstorm.permissions;
@@ -9,7 +9,11 @@ User.isOwner = function(user) {
   }
 };
 
+User.isOwnersUserId = function(userId) {
+  var user = Meteor.users.findOne({_id: userId});
+  return User.isOwner(user);
+};
 
 User.ownerLoggedIn = function() {
   return User.isOwner(Meteor.user());
-}
+};

--- a/navigation/_navigation.html
+++ b/navigation/_navigation.html
@@ -1,0 +1,9 @@
+<template name="_navigation">
+  <header class="navigation-bar__wrapper">
+    <h1 class="nagivation-bar__heading">SandForms</h1>
+    {{#if isOwner}}
+      <a class="nagivation-bar__links" href="/create">Create</a>
+      <a class="nagivation-bar__links" href="/responses">Responses</a>
+    {{/if}}
+  </header>
+</template>

--- a/navigation/client/navigation.js
+++ b/navigation/client/navigation.js
@@ -1,0 +1,5 @@
+Template._navigation.helpers({
+  isOwner: function() {
+    return User.ownerLoggedIn();
+  }
+});

--- a/packages/accounts-sandstorm-dev/insert-stub-headers.js
+++ b/packages/accounts-sandstorm-dev/insert-stub-headers.js
@@ -6,7 +6,7 @@ function defaults(value, fallback) {
   }
 }
 
-var STUB_PERMISSIONS = defaults(process.env.STUB_SANDSTORM_PERMISSIONS, 'owner');
+var STUB_PERMISSIONS = defaults(process.env.STUB_PERMISSIONS, 'owner');
 var STUB_USER_ID = defaults(process.env.STUB_USER_ID, 'dev-user-id');
 var STUB_USERNAME = defaults(process.env.STUB_USERNAME, 'Dev User');
 

--- a/tests/jasmine/client/integration/IsOwnerSpec.js
+++ b/tests/jasmine/client/integration/IsOwnerSpec.js
@@ -7,7 +7,7 @@ describe("isOwner", function() {
     };
 
     // When/Then
-    expect(Router.isOwner(user)).toBe(false);
+    expect(User.isOwner(user)).toBe(false);
   });
 
   it("should return true when the user has the owner permission", function() {
@@ -17,12 +17,12 @@ describe("isOwner", function() {
     };
 
     // When/Then
-    expect(Router.isOwner(user)).toBe(true);
+    expect(User.isOwner(user)).toBe(true);
   });
 
   it("should return false when the user is null", function() {
     // When
-    var isOwner = Router.isOwner(null);
+    var isOwner = User.isOwner(null);
 
     // Then
     expect(isOwner).toBe(false);

--- a/tests/jasmine/client/integration/StubUserPermissionsSpec.js
+++ b/tests/jasmine/client/integration/StubUserPermissionsSpec.js
@@ -2,16 +2,14 @@ describe("stubbing user permissions for tests", function() {
 
   it("should log us in as an owner", function(done) {
     withOwner(function() {
-      var permissions = Meteor.user().services.sandstorm.permissions;
-      expect(permissions).toContain('owner');
+      expect(User.ownerLoggedIn()).toBe(true);
       done();
     });
   });
 
   it("should let us log in without any permissions", function(done) {
     withNonOwner(function() {
-      var permissions = Meteor.user().services.sandstorm.permissions;
-      expect(permissions).not.toContain('owner');
+      expect(User.ownerLoggedIn()).toBe(false);
       done();
     });
   });


### PR DESCRIPTION
Essentially just adds an {{#if isOwner}} check around the navigation links, which are for owners only.

I also did some refactoring, pulling navigation into a separate template and added a User object with isOwner helper methods.
