### PR TITLE
Fix default route (and stop the wrong page from flashing up)

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -5,7 +5,6 @@
 # but you can also edit it by hand.
 
 meteor-platform
-kenton:accounts-sandstorm
 iron:router
 http
 sanjo:jasmine
@@ -20,3 +19,4 @@ waitingkuo:normalize
 accounts-sandstorm-dev
 konecty:mongo-counter
 jquery
+accounts-sandstorm

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,4 +1,5 @@
 accounts-base@1.2.0
+accounts-sandstorm@0.1.5
 accounts-sandstorm-dev@0.0.1
 amplify@1.0.0
 autoupdate@1.2.1
@@ -31,7 +32,6 @@ iron:router@1.0.9
 iron:url@1.0.9
 jquery@1.11.3_2
 json@1.0.3
-kenton:accounts-sandstorm@0.1.4
 konecty:mongo-counter@0.0.3
 launch-screen@1.0.2
 less@1.0.14

--- a/client/routes.js
+++ b/client/routes.js
@@ -1,18 +1,5 @@
 Router.configure({
-    layoutTemplate: 'index'
-});
-
-Router.route('/', function() {
-    if(Meteor.loggingIn()){
-        this.render('loading');
-        return;
-    }
-
-    if (User.ownerLoggedIn()) {
-        Router.go('create');
-    } else {
-        Router.go('welcome');
-    }
+  layoutTemplate: 'index'
 });
 
 Router.route('/create');
@@ -20,3 +7,16 @@ Router.route('/responses');
 Router.route('/submit');
 Router.route('/thanks');
 Router.route('/welcome');
+
+Router.route('/', function() {
+  this.subscribe('userData').wait();
+
+  if (!this.ready() || Meteor.loggingIn()) {
+      this.render('loading');
+  } else if (User.ownerLoggedIn()) {
+      Router.go('create');
+  } else {
+      Router.go('welcome');
+  }
+});
+

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,7 +1,9 @@
 User = {};
 
 User.isOwner = function(user) {
-  if (nullOrUndefined(user)) {
+  if (nullOrUndefined(user)
+      || nullOrUndefined(user.services)
+      || nullOrUndefined(user.services.sandstorm)) {
     return false;
   } else {
     var permissions = user.services.sandstorm.permissions;

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,9 +1,13 @@
 User = {};
 
+User.hasSandstormInfo = function(user) {
+  return !(nullOrUndefined(user)
+    || nullOrUndefined(user.services)
+    || nullOrUndefined(user.services.sandstorm));
+};
+
 User.isOwner = function(user) {
-  if (nullOrUndefined(user)
-      || nullOrUndefined(user.services)
-      || nullOrUndefined(user.services.sandstorm)) {
+  if (!User.hasSandstormInfo(user)) {
     return false;
   } else {
     var permissions = user.services.sandstorm.permissions;

--- a/packages/accounts-sandstorm/LICENSE
+++ b/packages/accounts-sandstorm/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+Licensed under the MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/packages/accounts-sandstorm/README.md
+++ b/packages/accounts-sandstorm/README.md
@@ -1,0 +1,62 @@
+Jack: Pulled from https://github.com/sandstorm-io/meteor-accounts-sandstorm in
+order to change the meteor version to 1.0.2 (the new version of this package
+adds a dependency on Meteor 1.2)
+
+When we upgrade to Meteor 1.2 this package can be removed from our repo and we
+can switch back to kenton:accounts-sandstorm from Atmosphere
+
+# Sandstorm.io login integration for Meteor.js
+
+[Sandstorm](https://sandstorm.io) is a platform for personal clouds that makes
+installing apps to your personal server as easy as installing apps to your
+phone.
+
+[Meteor](https://meteor.com) is a revolutionary web app framework. Sandstorm's
+own UI is built using Meteor, and Meteor is also a great way to build Sandstorm
+apps.
+
+This package is meant to be used by Meteor apps built to run on Sandstorm.
+It integrates with Sandstorm's built-in login system to log the user in
+automatically when they open the app. The user's `profile.name` will be
+populated from Sandstorm. When using this package, you should not use
+`accounts-ui` at all; just let login happen automatically.
+
+To use this package in your Meteor project, simply install it from the Meteor
+package repository:
+
+    meteor add kenton:accounts-sandstorm
+
+To package a Meteor app for Sandstorm,
+[use the `meteor-spk` tool](https://github.com/sandstorm-io/meteor-spk).
+
+## User profile info
+
+This package automatically populates `profile.name` based on the user's
+display name provided by Sandstorm. Sandstorm also provides [a bunch of
+other information](https://docs.sandstorm.io/en/latest/developing/auth/#headers-that-an-app-receives)
+about users that you may be interested in; `accounts-sandstorm` will
+place that information inside `services.sandstorm` in the user doc.
+
+The specific fields are:
+
+* `id`: From `X-Sandstorm-User-Id`; globally unique and stable
+  identifier for this user.
+* `picture`: From `X-Sandstorm-User-Picture`, URL of the user's preferred
+  avatar, or null if they don't have one.
+* `permissions`: From `X-Sandstorm-Permissions` (but parsed to a list),
+  the list of permissions the user has as determined by the Sandstorm
+  sharing model. Apps can define their own permissions.
+* `preferredHandle`: From `X-Sandstorm-Preferred-Handle`, the user's
+  preferred handle ("username", in the unix sense). This is NOT
+  guaranteed to be unique; it's just a different form of display name.
+* `pronouns`: From `X-Sandstorm-User-Pronouns`, indicates the pronouns
+  by which the user prefers to be referred.
+
+The package does not automatically publish any of these; it is up to your
+app to do so.
+
+## Development aids
+
+`accounts-sandstorm` normally only does anything when running inside Sandstorm. However, it's often a lot more convenient to develop Meteor apps using Meteor's normal dev tools which currently cannot run inside Sandstorm. This makes it hard to test your Sandstorm integration.
+
+To solve this, try using the package [`jacksingleton:accounts-sandstorm-dev`](https://atmospherejs.com/jacksingleton/accounts-sandstorm-dev), which lets you fake Sandstorm parameters even when running in regular dev mode outside Sandstorm!

--- a/packages/accounts-sandstorm/client.js
+++ b/packages/accounts-sandstorm/client.js
@@ -1,0 +1,43 @@
+// Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+Meteor.startup(function () {
+  Deps.autorun(function () {
+    if (!Meteor.userId()) {
+      // Accounts._setLoggingIn is a semi-private function, but it's also used in accounts-password.
+      Accounts._setLoggingIn(true);
+      HTTP.get("/.sandstorm-credentials", function (error, result) {
+        if (error) {
+          Accounts._setLoggingIn(false);
+          console.error(error.stack);
+        } else if (!result.data) {
+          Accounts._setLoggingIn(false);
+          console.error("/.sandstorm-credentials is not JSON?");
+        } else if (result.data.token) {
+          // Don't call Accounts._setLoggingIn here and let the normal login flow take over.
+          Meteor.loginWithToken(result.data.token, function() {});
+        } else {
+          Accounts._setLoggingIn(false);
+        }
+      });
+    }
+  });
+});

--- a/packages/accounts-sandstorm/package.js
+++ b/packages/accounts-sandstorm/package.js
@@ -1,0 +1,43 @@
+// Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+Package.describe({
+  summary: "Login service for Sandstorm.io applications",
+  version: "0.1.5",
+  name: "accounts-sandstorm",
+  git: "https://github.com/sandstorm-io/meteor-accounts-sandstorm.git"
+});
+
+Package.onUse(function(api) {
+  //api.versionsFrom('1.2');
+  api.versionsFrom('1.0.2');
+
+  api.use('random', 'server');
+  api.use('accounts-base');
+  api.use('webapp', 'server');
+  api.use('http', 'client');
+
+  // Export Accounts (etc) to packages using this one.
+  api.imply('accounts-base');
+
+  api.addFiles("client.js", "client");
+  api.addFiles("server.js", "server");
+});

--- a/packages/accounts-sandstorm/server.js
+++ b/packages/accounts-sandstorm/server.js
@@ -1,0 +1,77 @@
+// Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+WebApp.rawConnectHandlers.use(function (req, res, next) {
+  if (req.url === "/.sandstorm-credentials") {
+    handleCredentials(req, res);
+    return;
+  }
+  return next();
+});
+
+var handleCredentials = Meteor.bindEnvironment(function (req, res) {
+  try {
+    var permissions = req.headers["x-sandstorm-permissions"];
+    if (permissions && permissions !== "") {
+      permissions = permissions.split(",");
+    } else {
+      permissions = [];
+    }
+
+    var credentials = {
+      sandstormId: req.headers["x-sandstorm-user-id"] || null,
+      name: decodeURI(req.headers["x-sandstorm-username"]),
+      permissions: permissions,
+      picture: req.headers["x-sandstorm-user-picture"] || null,
+      preferredHandle: req.headers["x-sandstorm-preferred-handle"] || null,
+      pronouns: req.headers["x-sandstorm-user-pronouns"] || null
+    };
+
+    if (credentials.sandstormId) {
+      var login = Accounts.updateOrCreateUserFromExternalService(
+          "sandstorm", {
+            id: credentials.sandstormId,
+            permissions: permissions,
+            picture: credentials.picture,
+            preferredHandle: credentials.preferredHandle,
+            pronouns: credentials.pronouns
+          }, { profile: { name: credentials.name } });
+      console.log(login);
+      credentials.meteorId = login.userId;
+      var token = Accounts._generateStampedLoginToken();
+      credentials.token = token.token;
+      Accounts._insertLoginToken(login.userId, token);
+    }
+
+    var body = new Buffer(JSON.stringify(credentials));
+
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": body.length
+    });
+    res.end(body);
+  } catch (err) {
+    res.writeHead(500, {
+      "Content-Type": "text/plain"
+    });
+    res.end(err.stack);
+  }
+});

--- a/tests/jasmine/client/integration/IsOwnerSpec.js
+++ b/tests/jasmine/client/integration/IsOwnerSpec.js
@@ -27,4 +27,22 @@ describe("isOwner", function() {
     // Then
     expect(isOwner).toBe(false);
   });
+
+  it("should return false when the sandstorm object is undefined", function() {
+    // Given
+    var user = {
+      services: {}
+    }
+
+    // When / Then
+    expect(User.isOwner(user)).toBe(false);
+  })
+
+  it("should return false when the services object is undefined", function() {
+    // Given
+    var user = {};
+
+    // When / Then
+    expect(User.isOwner(user)).toBe(false);
+  })
 });


### PR DESCRIPTION
Fixes a bug where the owner would see the welcome page, and also fixes the problem we were having before that where the wrong page would flash up momentarily in a jarring way.

This required a change to meteor-accounts-sandstorm which was made here: https://github.com/sandstorm-io/meteor-accounts-sandstorm/pull/8

I've pulled the meteor-accounts-sandstorm package into our repo (with this PR applied) for now because the latest version declares a dependency on Meteor 1.2, so we won't be able to pull it into our app even after this PR is merged and published to Atmosphere. Once we switch over to 1.2 (should be right after our first release to the app market) we can switch back to pulling it from Atmosphere. This is tracked here: https://trello.com/c/wxzZuyyj/98-switch-back-to-kenton-accounts-sandstorm-once-we-ve-upgraded-to-meteor-1-2
