### PR TITLE
Less deleted delete

### DIFF
--- a/TODO
+++ b/TODO
@@ -4,6 +4,6 @@
   - [x] create page
   - [x] submit page
 - [x] get prompts including deleted = true on responses page
-- [ ] remove duplicate notDeleted query objects
+- [x] remove duplicate notDeleted query objects
 - [ ] delete getPromptContent
 - [ ] data gone after reset bug

--- a/TODO
+++ b/TODO
@@ -1,9 +1,0 @@
-- [x] delete -> set deleted = true
-
-- [x] get prompts -> where deleted == false
-  - [x] create page
-  - [x] submit page
-- [x] get prompts including deleted = true on responses page
-- [x] remove duplicate notDeleted query objects
-- [x] delete getPromptContent
-- [x] data gone after reset bug

--- a/TODO
+++ b/TODO
@@ -5,5 +5,5 @@
   - [x] submit page
 - [x] get prompts including deleted = true on responses page
 - [x] remove duplicate notDeleted query objects
-- [ ] delete getPromptContent
-- [ ] data gone after reset bug
+- [x] delete getPromptContent
+- [x] data gone after reset bug

--- a/TODO
+++ b/TODO
@@ -1,0 +1,9 @@
+- [x] delete -> set deleted = true
+
+- [x] get prompts -> where deleted == false
+  - [x] create page
+  - [x] submit page
+- [x] get prompts including deleted = true on responses page
+- [ ] remove duplicate notDeleted query objects
+- [ ] delete getPromptContent
+- [ ] data gone after reset bug

--- a/collections/prompts.js
+++ b/collections/prompts.js
@@ -43,14 +43,23 @@ Prompts.allPromptIds = function() {
   });
 };
 
-Prompts.inOrder = function() {
-  var notDeleted = {
-    $or: [
+Prompts.inOrder = function(maybeOptions) {
+  var options = _(
+    nullOrUndefined(maybeOptions) ? {} : maybeOptions
+  ).defaults({
+    deleted : false
+  });
+
+  var queryObject = {};
+
+  if (!options.deleted) {
+    queryObject['$or'] = [
       { "deleted": { $exists: false }},
       { "deleted": false }
-    ]
-  };
-  return Prompts.find(notDeleted, {sort: ['order']}).fetch();
+    ];
+  }
+
+  return Prompts.find(queryObject, {sort: ['order']}).fetch();
 };
 
 Prompts.getPromptContent = function() {

--- a/collections/prompts.js
+++ b/collections/prompts.js
@@ -43,12 +43,6 @@ Prompts.inOrder = function(maybeOptions) {
   return Prompts.find(queryObject, {sort: ['order']}).fetch();
 };
 
-Prompts.getPromptContent = function() {
-  return Prompts.find().map(function(prompt) {
-    return prompt.text;
-  });
-};
-
 Prompts.markAsDeleted = function(promptId) {
   Prompts.update(
     { _id: promptId },

--- a/collections/prompts.js
+++ b/collections/prompts.js
@@ -31,19 +31,32 @@ Prompts.create = function(promptText) {
   return Meteor.call('Prompts.create', promptText);
 };
 
-Prompts.allPromptIds = function() {
-  var notDeleted = {
-    $or: [
-      { "deleted": { $exists: false }},
-      { "deleted": false }
-    ]
-  };
-  return Prompts.find(notDeleted).map(function(prompt) {
+Prompts.allPromptIds = function(maybeOptions) {
+  var queryObject = _buildQueryFromOptions(maybeOptions);
+  return Prompts.find(queryObject).map(function(prompt) {
     return prompt._id;
   });
 };
 
 Prompts.inOrder = function(maybeOptions) {
+  var queryObject = _buildQueryFromOptions(maybeOptions);
+  return Prompts.find(queryObject, {sort: ['order']}).fetch();
+};
+
+Prompts.getPromptContent = function() {
+  return Prompts.find().map(function(prompt) {
+    return prompt.text;
+  });
+};
+
+Prompts.markAsDeleted = function(promptId) {
+  Prompts.update(
+    { _id: promptId },
+    { $set: { "deleted": true } }
+  );
+};
+
+function _buildQueryFromOptions(maybeOptions) {
   var options = _(
     nullOrUndefined(maybeOptions) ? {} : maybeOptions
   ).defaults({
@@ -59,18 +72,5 @@ Prompts.inOrder = function(maybeOptions) {
     ];
   }
 
-  return Prompts.find(queryObject, {sort: ['order']}).fetch();
-};
-
-Prompts.getPromptContent = function() {
-  return Prompts.find().map(function(prompt) {
-    return prompt.text;
-  });
-};
-
-Prompts.markAsDeleted = function(promptId) {
-  Prompts.update(
-    { _id: promptId },
-    { $set: { "deleted": true } }
-  );
+  return queryObject;
 }

--- a/collections/prompts.js
+++ b/collections/prompts.js
@@ -44,7 +44,13 @@ Prompts.allPromptIds = function() {
 };
 
 Prompts.inOrder = function() {
-  return Prompts.find({}, {sort: ['order']}).fetch();
+  var notDeleted = {
+    $or: [
+      { "deleted": { $exists: false }},
+      { "deleted": false }
+    ]
+  };
+  return Prompts.find(notDeleted, {sort: ['order']}).fetch();
 };
 
 Prompts.getPromptContent = function() {

--- a/collections/prompts.js
+++ b/collections/prompts.js
@@ -32,7 +32,13 @@ Prompts.create = function(promptText) {
 };
 
 Prompts.allPromptIds = function() {
-  return Prompts.find().map(function(prompt) {
+  var notDeleted = {
+    $or: [
+      { "deleted": { $exists: false }},
+      { "deleted": false }
+    ]
+  };
+  return Prompts.find(notDeleted).map(function(prompt) {
     return prompt._id;
   });
 };
@@ -46,3 +52,10 @@ Prompts.getPromptContent = function() {
     return prompt.text;
   });
 };
+
+Prompts.markAsDeleted = function(promptId) {
+  Prompts.update(
+    { _id: promptId },
+    { $set: { "deleted": true } }
+  );
+}

--- a/prompts/client/create.js
+++ b/prompts/client/create.js
@@ -23,11 +23,9 @@ if (Meteor.isClient) {
         {_id: promptId},
         {$set: {"text": text}}
       );
-    }, 
+    },
     "click .deleteX":function(prompt){
-      Prompts.remove(
-        {_id: this._id}
-      );
+      Prompts.markAsDeleted(this._id);
     }
   });
 }

--- a/responses/client/responses.js
+++ b/responses/client/responses.js
@@ -1,13 +1,14 @@
 Template.responses.helpers({
 
   prompts: function() {
-    return Prompts.inOrder();
+    return Prompts.inOrder({ deleted: true });
   },
 
   responsesInOrder: function() {
-    return Submissions.inTableFormat(Prompts.inOrder());
+    return Submissions.inTableFormat(
+      Prompts.inOrder({ deleted: true })
+    );
   }
-
 });
 
 Template.responses.events({

--- a/tests/jasmine/server/integration/PromptsSpec.js
+++ b/tests/jasmine/server/integration/PromptsSpec.js
@@ -61,7 +61,7 @@ describe("prompts", function() {
     expect(prompts[0].text).toEqual('Your favorite book?');
   });
 
-  it("should delete a prompt when markAsDeleted is called", function(){
+  it("should not return deleted prompt ids", function(){
     // Given
     Prompts.remove({});
     var id = Prompts.create({text: 'What is your favorite color?'});
@@ -74,5 +74,20 @@ describe("prompts", function() {
 
     expect(promptIds.length).toBe(0);
     expect(promptIds).not.toContain(id);
+  });
+
+  it ("should not return deleted prompts when inOrder is called", function() {
+    // Given
+    Prompts.remove({});
+    var id = Prompts.create({text: 'What is your favorite color?'});
+
+    // When
+    Prompts.markAsDeleted(id);
+
+    // Then
+    var prompts = Prompts.inOrder();
+
+    expect(prompts.length).toBe(0);
+    expect(prompts).not.toContain(id);
   });
 });

--- a/tests/jasmine/server/integration/PromptsSpec.js
+++ b/tests/jasmine/server/integration/PromptsSpec.js
@@ -61,16 +61,17 @@ describe("prompts", function() {
     expect(prompts[0].text).toEqual('Your favorite book?');
   });
 
-  it("should delete a prompt when remove is called", function(){
+  it("should delete a prompt when markAsDeleted is called", function(){
     // Given
     Prompts.remove({});
     var id = Prompts.create({text: 'What is your favorite color?'});
 
     // When
-    Prompts.remove(id);
+    Prompts.markAsDeleted(id);
 
     // Then
     var promptIds = Prompts.allPromptIds();
+
     expect(promptIds.length).toBe(0);
     expect(promptIds).not.toContain(id);
   });

--- a/tests/jasmine/server/integration/PromptsSpec.js
+++ b/tests/jasmine/server/integration/PromptsSpec.js
@@ -41,15 +41,6 @@ describe("prompts", function() {
     expect(order).toBe(3);
   });
 
-  it("should return all prompts' content", function() {
-      Prompts.remove({});
-      Prompts.create('hello');
-      Prompts.create('world');
-
-      var prompts = Prompts.getPromptContent();
-      expect(prompts).toEqual(['hello', 'world']);
-  });
-
   it("should return all prompts in creation order", function() {
     Counters.remove({})
     Prompts.remove({});

--- a/tests/jasmine/server/integration/PromptsSpec.js
+++ b/tests/jasmine/server/integration/PromptsSpec.js
@@ -76,7 +76,7 @@ describe("prompts", function() {
     expect(promptIds).not.toContain(id);
   });
 
-  it ("should not return deleted prompts when inOrder is called", function() {
+  it("should not return deleted prompts when inOrder is called", function() {
     // Given
     Prompts.remove({});
     var id = Prompts.create({text: 'What is your favorite color?'});
@@ -89,5 +89,19 @@ describe("prompts", function() {
 
     expect(prompts.length).toBe(0);
     expect(prompts).not.toContain(id);
+  });
+
+  it("should return deleted prompts when the deleted option is passed to inOrder", function() {
+    // Given
+    Prompts.remove({});
+    var id = Prompts.create({text: 'What is your favorite color?'});
+
+    // When
+    Prompts.markAsDeleted(id);
+
+    // Then
+    var prompts = Prompts.inOrder({ deleted: true });
+
+    expect(prompts.length).toBe(1);
   });
 });


### PR DESCRIPTION
Instead of removing deleted Prompts from the database, we now mark them as deleted and do not show them on the Create or Submit pages. We still show them on the responses table though, as someone might have submitted a Response for that Prompt.

This behavior is consistent with Google Forms - which I think is a good enough start. We can definitely think about better ways to do it after the initial launch though!
