### PR TITLE
Audit argument checks

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -20,3 +20,4 @@ accounts-sandstorm-dev
 konecty:mongo-counter
 jquery
 accounts-sandstorm
+audit-argument-checks

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -2,6 +2,7 @@ accounts-base@1.2.0
 accounts-sandstorm@0.1.5
 accounts-sandstorm-dev@0.0.1
 amplify@1.0.0
+audit-argument-checks@1.0.3
 autoupdate@1.2.1
 base64@1.0.3
 binary-heap@1.0.3

--- a/collections/prompts.js
+++ b/collections/prompts.js
@@ -19,6 +19,7 @@ if (Meteor.isServer) {
 
   Meteor.methods({
     'Prompts.create': function(promptText) {
+      check(promptText, String);
       var order = incrementCounter(Counters, "promptOrder");
       if(promptText != "") {
           return Prompts.insert({text: promptText, order: order});

--- a/packages/accounts-sandstorm-dev/insert-stub-headers.js
+++ b/packages/accounts-sandstorm-dev/insert-stub-headers.js
@@ -36,6 +36,7 @@ Meteor.startup(function () {
 Meteor.methods({
 
   stubPermissions: function(permissions) {
+    check(permissions, [String]);
     STUB_PERMISSIONS = permissions.join(',');
   }
 });

--- a/tests/jasmine/server/integration/PromptsSpec.js
+++ b/tests/jasmine/server/integration/PromptsSpec.js
@@ -3,7 +3,7 @@ describe("prompts", function() {
   it("should let us get all prompt ids", function() {
     // Given
     Prompts.remove({});
-    var id = Prompts.create({text: 'What is your favorite color?'});
+    var id = Prompts.create('What is your favorite color?');
 
     // When
     var promptIds = Prompts.allPromptIds();
@@ -55,7 +55,7 @@ describe("prompts", function() {
   it("should not return deleted prompt ids", function(){
     // Given
     Prompts.remove({});
-    var id = Prompts.create({text: 'What is your favorite color?'});
+    var id = Prompts.create('What is your favorite color?');
 
     // When
     Prompts.markAsDeleted(id);
@@ -70,7 +70,7 @@ describe("prompts", function() {
   it("should not return deleted prompts when inOrder is called", function() {
     // Given
     Prompts.remove({});
-    var id = Prompts.create({text: 'What is your favorite color?'});
+    var id = Prompts.create('What is your favorite color?');
 
     // When
     Prompts.markAsDeleted(id);
@@ -85,7 +85,7 @@ describe("prompts", function() {
   it("should return deleted prompts when the deleted option is passed to inOrder", function() {
     // Given
     Prompts.remove({});
-    var id = Prompts.create({text: 'What is your favorite color?'});
+    var id = Prompts.create('What is your favorite color?');
 
     // When
     Prompts.markAsDeleted(id);


### PR DESCRIPTION
This pull request adds the audit-argument-checks system to sandforms. This package will automatically check to see that we are using input validation whenever we have arguments in our Meteor.publish and Meteor.methods calls.

Anyone care to mongo inject some objects for QA? ;)

Adding the auditing package also caused the async tests with authorization and permission to fail. Removing async calls and the setup fixtures caused the tests to pass. Not the nicest solution, but it did work. This also resulted in a heavy delete of the test helper code because the changes resulted in it not being used anywhere. If you have suggestions for a better solution to the test failures, let me know. 

We still have a lot to do before we can publish to the app market tho, and this was the quickest solution. 
