### PR TITLE
fix prompt editing

### DIFF
--- a/prompts/_prompt.html
+++ b/prompts/_prompt.html
@@ -1,6 +1,6 @@
 <template name="_prompt">
-  <form class="row" data-prompt-id="{{_id}}">
-    <input class="col s9 m10 offset-s1 offset-m1" type="text" name="prompt" value="{{text}}" tabindex="1"/>
+  <form class="row create-survey__update-form">
+    <input class="col s9 m10 offset-s1 offset-m1" type="text" name="prompt" data-prompt-id="{{_id}}" value="{{text}}" tabindex="1"/>
     <a href="#" class="btn-floating deleteX"><i class="material-icons" tabIndex="0">not_interested</i></a>
   </form>
 </template>

--- a/prompts/client/create.js
+++ b/prompts/client/create.js
@@ -14,16 +14,18 @@ if (Meteor.isClient) {
       Prompts.create(text);
       event.target.prompt.value = "";
     },
-    "submit .create-survey__update-form": function (event) {
+
+    "keyup .create-survey__update-form": _.debounce(function (event) {
       event.preventDefault();
-      var text = event.target.prompt.value;
+      var text = event.target.value;
       var promptId = $(event.target).data('prompt-id');
 
       Prompts.update(
         {_id: promptId},
         {$set: {"text": text}}
       );
-    },
+    }, 200),
+
     "click .deleteX":function(prompt){
       Prompts.markAsDeleted(this._id);
     }


### PR DESCRIPTION
We'd removed a class that we were using in the prompts event handler for edit, so added that class back to the template so that save would work.

I've also switched the edit event handler to trigger on keyup, and debounced for 200 milliseconds. http://underscorejs.org/#debounce
